### PR TITLE
fixes the version to googleapis v2.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "google-compute-metadata": "^1.2.0",
-    "googleapis": "^2.0.6",
+    "googleapis": "<=2.1.6",
     "slowloris": "^0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
CL v1.beta3 has been deleted since the googleapis v2.1.7.
https://github.com/google/google-api-nodejs-client/pull/497/commits

so, fixes the version to googleapis v2.1.6.
(we need to be migrated to CL v2.beta1 ... https://cloud.google.com/logging/docs/api/introduction_v2)