### PR TITLE
[modules] Google API updates

### DIFF
--- a/lib/winston-gcl.js
+++ b/lib/winston-gcl.js
@@ -8,7 +8,7 @@
 
 var events = require('events'),
     google = require('googleapis'),
-    cloudlogging = google.logging("v1beta3").projects,
+    cloudlogging = google.logging("v2beta1").projects,
     util = require('util'),
     winston = require('winston'),
     googleMetadata = require("google-compute-metadata"),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-gcl",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A Google Cloud Logging transport for winston",
   "author": "Lars Jacob <lars@iamat.com>",
   "repository": {
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "google-compute-metadata": "^1.2.0",
-    "googleapis": "~2.0.6",
+    "googleapis": "^14.0.0",
     "slowloris": "^0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Google Logging api v1 will be deprecated on March 30, 2017. So
that, we need to update google api version.

**WARNING**
Now a day LogViewer doesn't support Google Logging API V2 format.  So that, if you use LogViewer any feature listed below you should delay the migration of the api:

1. Filters
2. Log exports to BigQuery
3. Custom metrics

Consider this reading: [https://cloud.google.com/logging/docs/api/v2/migration-to-v2#deciding_to_migrate](https://cloud.google.com/logging/docs/api/v2/migration-to-v2#deciding_to_migrate)